### PR TITLE
feat: 로컬 환경 셋업 + Kafka SSL + Gradle 의존성 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+DB_URL=localhost:5439/company_db
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+EUREKA_SERVER_URL=http://localhost:18761/eureka
+BOOTSTRAP_SERVERS=<GCP Kafka broker public IPs (콤마 구분)>
+KAFKA_BOOTSTRAP_SERVERS=<위와 동일>
+TRUST_STORE_PASSWORD=<truststore 비번 — 팀 슬랙 별도 공유>
+TMAP_API_KEY=<TMap API 키>

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment & Secrets ###
+.env
+!.env.example
+
+### Kafka SSL truststore (gitignored, 팀 슬랙 별도 공유) ###
+src/main/resources/ssl/

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     // 5. Test (Common에 없는 테스트 라이브러리만 추가)
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/loopang/company_service/CompanyServiceApplication.java
+++ b/src/main/java/com/loopang/company_service/CompanyServiceApplication.java
@@ -2,13 +2,10 @@ package com.loopang.company_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 
+// @EnableFeignClients는 common 라이브러리(FeignConfig)에서 basePackages = "com.loopang"으로
+// 이미 등록되므로 여기 명시하면 같은 FeignClient가 두 번 스캔되어 빈 중복 등록 에러 발생.
 @SpringBootApplication
-@EnableFeignClients(
-    // FeignClient 인터페이스가 위치한 패키지를 명시적으로 지정
-    basePackages = "com.loopang.company_service.infrastructure.client"
-)
 public class CompanyServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 18102
+
 spring:
   application:
     name: company-service
@@ -14,15 +17,38 @@ spring:
         enabled: true
         service-id: config-server
 
-  # datasource & jpa 설정은 config-server
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_URL:localhost:5439/company_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: ${DB_DDL_AUTO:update}
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
 
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    bootstrap-servers: ${BOOTSTRAP_SERVERS:${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}}
+    properties:
+      security.protocol: SSL
+      ssl.endpoint.identification.algorithm: ""
+    ssl:
+      trust-store-location: classpath:ssl/kafka.server.truststore.jks
+      trust-store-password: ${TRUST_STORE_PASSWORD}
+      trust-store-type: PKCS12
     consumer:
       group-id: company-service-group
+      enable-auto-commit: false
       # value를 String으로 읽어와야 코드의 record.value()가 String
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      auto-offset-reset: earliest
+    listener:
+      ack-mode: manual
+      concurrency: 3
 
 eureka:
   client:
@@ -33,4 +59,4 @@ eureka:
 
 tmap:
   api:
-    key: ${TMAP_API_KEY}
+    key: ${TMAP_API_KEY:}


### PR DESCRIPTION
## 배경

다른 도메인 서비스(hub/user/route 등)와 동일한 로컬 개발 환경 패턴으로 company-service를 정렬합니다. 기존엔 \`build.gradle\`이 common 0.0.1-SNAPSHOT을 가리켜 Outbox/Inbox 엔티티를 JPA에 등록하지 못해 startup이 실패했고, Kafka SSL 설정도 빠져 있어 GCP Kafka에 붙을 수 없었습니다.

## 변경 내용

### \`build.gradle\`
- common 라이브러리 \`0.0.1-SNAPSHOT\` → \`0.0.5-SNAPSHOT\` 업그레이드
- \`me.paulschwarz:spring-dotenv:4.0.0\` 추가 — 모듈 root의 \`.env\` 파일 자동 로드

### \`CompanyServiceApplication.java\`
- \`@EnableFeignClients\` 제거. common 라이브러리(\`FeignConfig\`)가 \`basePackages = "com.loopang"\`으로 이미 자동 등록하므로, 여기에 또 명시하면 같은 \`FeignClientSpecification\` 빈이 두 번 등록되어 startup 실패.

### \`application.yaml\`
- \`spring.datasource\` + \`spring.jpa\` 설정 추가 (Config Server 의존 최소화 + 로컬 default 값 명시)
- \`spring.kafka\`에 SSL 설정 추가:
  - \`security.protocol: SSL\`
  - \`ssl.trust-store-location: classpath:ssl/kafka.server.truststore.jks\`
  - \`ssl.trust-store-type: PKCS12\` ← 파일명은 \`.jks\`이지만 실제 형식이 PKCS12라 명시 안 하면 "keystore password was incorrect" 에러로 위장됨
- \`spring.kafka.bootstrap-servers\` default 우선순위: \`BOOTSTRAP_SERVERS\` → \`KAFKA_BOOTSTRAP_SERVERS\` → \`localhost:9092\` (env 변수 통일성)
- consumer 설정 보강 (\`auto-offset-reset\`, \`listener.ack-mode\` 등)
- \`server.port: 18102\` 명시 (8080 default라 user-service와 충돌)
- \`tmap.api.key\` default를 빈 문자열로 변경 (env 미지정 시에도 startup 통과)

### \`.gitignore\`
- \`.env\` (시크릿) 차단
- \`src/main/resources/ssl/\` (truststore) 차단
- \`!.env.example\`은 허용

### \`.env.example\` (신규)
- 로컬 환경 변수 템플릿. 실제 \`.env\`는 gitignored.

## 검증

로컬에서 정상 기동 확인:
- ✅ PostgreSQL \`localhost:5439/company_db\` 연결 OK
- ✅ Kafka SSL 핸드쉐이크 통과 후 5개 토픽 partition 할당
  - \`hub-update-topic\`, \`user-update-topic\`
  - \`delivery-cleanup-topic\`, \`order-cleanup-topic\`, \`product-cleanup-topic\`
- ✅ Outbox poller 정상 동작
- ✅ Eureka에 \`COMPANY-SERVICE\` 등록 (포트 18102)

## 주의사항

이 PR을 머지한 후 로컬에서 띄우려면:
1. 모듈 root에 \`.env\` 파일 작성 (\`.env.example\` 참고)
2. \`src/main/resources/ssl/kafka.server.truststore.jks\` 파일 배치 (팀 슬랙에서 수령)
3. IntelliJ Run Configuration에서 **Working directory**를 모듈 절대 경로(\`/Users/.../company-service\`)로 설정 — 멀티모듈 IntelliJ 프로젝트에서 spring-dotenv가 \`.env\`를 찾도록

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Configuration**
  * 환경 변수 템플릿 파일 추가로 데이터베이스, Kafka, TMap API 등 외부 서비스 설정 구성 가능
  * 서버 포트 설정 추가 (18102)
  * Kafka SSL 지원 및 수동 커밋 모드 활성화
  * Kafka 리스너 동시성 설정으로 메시지 처리 성능 최적화

* **Chores**
  * 의존성 라이브러리 추가
  * 환경 파일 관리 설정 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->